### PR TITLE
Fix local dataset import path

### DIFF
--- a/evaluation/evaluate_ekf.py
+++ b/evaluation/evaluate_ekf.py
@@ -1,6 +1,6 @@
 # output the trajctory in the world frame for visualization and evaluation
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 import os
 import json

--- a/evaluation/evaluate_motion.py
+++ b/evaluation/evaluate_motion.py
@@ -1,6 +1,6 @@
 # output the trajctory in the world frame for visualization and evaluation
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 import os
 import json

--- a/evaluation/save_ori.py
+++ b/evaluation/save_ori.py
@@ -1,6 +1,6 @@
 # output the trajctory in the world frame for visualization and evaluation
 import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 import os
 import argparse


### PR DESCRIPTION
## Summary
- prioritize project modules over external packages in evaluation scripts

## Testing
- `python -m py_compile evaluation/evaluate_motion.py evaluation/evaluate_ekf.py evaluation/save_ori.py`


------
https://chatgpt.com/codex/tasks/task_e_687730ad6c84832cbe0293c378c91909