### PR TITLE
Add explicit ONNX export wrapper

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,4 +1,5 @@
 from .code import *
+from .onnx_wrapper import ONNXWrapper
 
 net_dict = {
     'codenetmotion':CodeNetMotion,

--- a/model/onnx_wrapper.py
+++ b/model/onnx_wrapper.py
@@ -1,0 +1,19 @@
+import torch
+
+
+class ONNXWrapper(torch.nn.Module):
+    """Wrapper module for ONNX export.
+
+    This module converts the network that expects a dictionary input into a
+    module with explicit tensor arguments, which allows the exported ONNX graph
+    to have named inputs.
+    """
+
+    def __init__(self, network: torch.nn.Module):
+        super().__init__()
+        self.network = network
+
+    def forward(self, acc: torch.Tensor, gyro: torch.Tensor, rot: torch.Tensor):
+        data = {"acc": acc, "gyro": gyro}
+        out = self.network(data, rot)
+        return out["net_vel"], out["cov"]


### PR DESCRIPTION
## Summary
- add ONNXWrapper to call motion network with tensor args for ONNX export
- export ONNX model with named inputs/outputs instead of dictionary

## Testing
- `python -m py_compile Air-IO/model/onnx_wrapper.py Air-IO/model/__init__.py Air-IO/inference_motion.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5caa28c10832c9e39f5b589c06b3b