### PR TITLE
Fix ONNX export by exposing explicit sensor inputs and dynamic sequence length

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,6 +1,12 @@
 from .code import *
+from .onnx_wrapper import ONNXWrapper
 
 net_dict = {
-    'codenetmotion':CodeNetMotion,
-    'codewithrot':CodeNetMotionwithRot,
+    'codenetmotion': CodeNetMotion,
+    'codewithrot': CodeNetMotionwithRot,
 }
+
+__all__ = [
+    'ONNXWrapper',
+    'net_dict',
+]

--- a/model/onnx_wrapper.py
+++ b/model/onnx_wrapper.py
@@ -1,0 +1,20 @@
+import torch.nn as nn
+
+class ONNXWrapper(nn.Module):
+    """Expose explicit tensor inputs for ONNX export.
+
+    The underlying network expects a dictionary of IMU tensors plus a rotation
+    tensor and returns a dictionary containing ``net_vel`` and ``cov``.  ONNX
+    does not support dictionary inputs or outputs, so this wrapper flattens the
+    interface to three tensor arguments (``acc``, ``gyro``, ``rot``) and two
+    tensor outputs (``net_vel``, ``cov``).
+    """
+
+    def __init__(self, net: nn.Module):
+        super().__init__()
+        self.net = net
+
+    def forward(self, acc, gyro, rot):  # pragma: no cover - simple wrapper
+        out = self.net({'acc': acc, 'gyro': gyro}, rot)
+        return out['net_vel'], out['cov']
+


### PR DESCRIPTION
## Summary
- expose covariance output and allow variable sequence length during ONNX export
- update ONNX runtime feed/output to include `acc`, `gyro`, `rot` inputs and `net_vel`, `cov` outputs
- document interface in an `ONNXWrapper` wrapper

## Testing
- `python -m py_compile inference_motion.py inference_onnx.py model/onnx_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c894c550832c88c7519c1342c7f0